### PR TITLE
fix(workflow): correct translate.yml indentation & usage notes

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -8,18 +8,27 @@ jobs:
   translate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with: python-version: '3.11'
-      - run: pip install deep-translator
-      - run: python .github/scripts/auto_translate.py
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install deep-translator
+
+      - name: Run translation script
+        run: python .github/scripts/auto_translate.py
         env:
           TARGET_LANGS: "hi,es,fr"
-      - name: Create PR
+
+      - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(docs): add machine-translated docs"
           branch: translation/auto
           title: "Auto: add machine-translated docs"
-          body: "Machine-generated translations. Please review."
+          body: "Machine-generated translations. Please review and refine."


### PR DESCRIPTION
### Summary

Fixes YAML indentation and step mappings in `.github/workflows/translate.yml` so the job runs correctly.

### What I changed
- Corrected `with:` indentation for `actions/setup-python`.\n- Ensured `run` and `env` keys are at the correct mapping levels.

### Why
The previous workflow failed during parsing/execution due to invalid YAML structure. This PR fixes the YAML so the Action can run and create machine-translation PRs as intended.

### Notes & safety recommendations\n- The helper script (`.github/scripts/auto_translate.py`) uses `deep-translator` which scrapes Google Translate. It is intended for **drafts** only and can be flaky in CI. I recommend not enabling scheduled runs until maintainers:
  1. Approve the approach, and
    2. Preferably switch to an official translation API (Google Cloud Translate or DeepL) and store API credentials in GitHub Secrets.
    - This PR **only** changes the workflow file (.github/workflows/translate.yml). No docs or secrets were modified.
    closes #15 
    
    ### How to test
    . After merge (or on this branch), go to Actions → Auto-translate docs → Run workflow → select this branch.
    . Inspect the logs for Checkout → Setup Python → Install deps → Run script → Create PR steps.
    Please review and approve. Thanks!'
    
    