### PR TITLE
✨ feat(auth): add JWT authentication filter and utilities ( JWT based authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,27 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/com/hacktober/blog/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hacktober/blog/config/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.hacktober.blog.config;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String jwt = parseJwt(request);
+            if (jwt != null && jwtUtils.validateJwtToken(jwt)) {
+                String username = jwtUtils.getUserNameFromJwtToken(jwt);
+
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            logger.error("Cannot set user authentication: {}", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseJwt(HttpServletRequest request) {
+        String headerAuth = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(headerAuth) && headerAuth.startsWith("Bearer ")) {
+            return headerAuth.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/hacktober/blog/config/JwtUtils.java
+++ b/src/main/java/com/hacktober/blog/config/JwtUtils.java
@@ -1,0 +1,90 @@
+package com.hacktober.blog.config;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtUtils {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private int jwtExpirationMs;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    public String generateJwtToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        List<String> roles = userPrincipal.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        return Jwts.builder()
+                .setSubject(userPrincipal.getUsername())
+                .claim("roles", roles)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUserNameFromJwtToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getRolesFromJwtToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return (List<String>) claims.get("roles");
+    }
+
+    public boolean validateJwtToken(String authToken) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(authToken);
+            return true;
+        } catch (MalformedJwtException e) {
+            System.err.println("Invalid JWT token: " + e.getMessage());
+        } catch (ExpiredJwtException e) {
+            System.err.println("JWT token is expired: " + e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            System.err.println("JWT token is unsupported: " + e.getMessage());
+        } catch (IllegalArgumentException e) {
+            System.err.println("JWT claims string is empty: " + e.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/hacktober/blog/config/SecurityConfig.java
+++ b/src/main/java/com/hacktober/blog/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package com.hacktober.blog.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Autowired
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider(passwordEncoder());
+        authProvider.setUserDetailsService(userDetailsService);
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/login").permitAll()
+                        .requestMatchers("/users/register").permitAll()
+                        .anyRequest().authenticated());
+
+        http.authenticationProvider(authenticationProvider());
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/hacktober/blog/config/UserDetailsServiceImpl.java
+++ b/src/main/java/com/hacktober/blog/config/UserDetailsServiceImpl.java
@@ -1,0 +1,38 @@
+package com.hacktober.blog.config;
+
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.firebase.cloud.FirestoreClient;
+import com.hacktober.blog.user.User;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        try {
+            Firestore db = FirestoreClient.getFirestore();
+            DocumentSnapshot doc = db.collection("users").document(username).get().get();
+
+            if (!doc.exists()) {
+                throw new UsernameNotFoundException("User not found: " + username);
+            }
+
+            User user = doc.toObject(User.class);
+            if (user == null) {
+                throw new UsernameNotFoundException("User not found: " + username);
+            }
+
+            return UserPrincipal.create(user);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new UsernameNotFoundException("Error loading user: " + username, e);
+        }
+    }
+}

--- a/src/main/java/com/hacktober/blog/config/UserPrincipal.java
+++ b/src/main/java/com/hacktober/blog/config/UserPrincipal.java
@@ -1,0 +1,65 @@
+package com.hacktober.blog.config;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hacktober.blog.user.User;
+
+public class UserPrincipal implements UserDetails {
+    private String username;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    public UserPrincipal(String username, String password, List<String> roles) {
+        this.username = username;
+        this.password = password;
+        this.authorities = roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    public static UserPrincipal create(User user) {
+        List<String> roles = user.getRoles() != null ? user.getRoles() : List.of("ROLE_USER");
+        return new UserPrincipal(user.getUsername(), user.getPassword(), roles);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/hacktober/blog/login/LoginController.java
+++ b/src/main/java/com/hacktober/blog/login/LoginController.java
@@ -1,14 +1,24 @@
 package com.hacktober.blog.login;
 
-import com.hacktober.blog.exceptions.UnauthorizedException;
-import com.hacktober.blog.utils.ApiResponse;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hacktober.blog.config.JwtUtils;
+import com.hacktober.blog.exceptions.UnauthorizedException;
+import com.hacktober.blog.utils.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,12 +30,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class LoginController {
 
     @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
     private LoginService loginService;
 
     @PostMapping
-    @Operation(summary = "Authenticate user", description = "Validate a username and password against stored credentials.")
+    @Operation(summary = "Authenticate user", description = "Validate a username and password and return JWT token.")
     public ResponseEntity<ApiResponse<Map<String, Object>>> login(@RequestParam String username,
-                                     @RequestParam String password)
+            @RequestParam String password)
             throws InterruptedException, ExecutionException {
 
         boolean success = loginService.login(username, password);
@@ -34,6 +50,14 @@ public class LoginController {
         data.put("login", success);
 
         if (success) {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(username, password));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            String jwt = jwtUtils.generateJwtToken(authentication);
+
+            data.put("token", jwt);
+            data.put("tokenType", "Bearer");
             data.put("message", "Login successful");
             return ResponseEntity.ok(ApiResponse.success(data, "Login successful"));
         } else {

--- a/src/main/java/com/hacktober/blog/user/User.java
+++ b/src/main/java/com/hacktober/blog/user/User.java
@@ -5,34 +5,70 @@ import java.util.List;
 public class User {
 
     private String name;
-    private String username;   // document id
+    private String username; // document id
     private String email;
-    private String password;   // will be stored as Base64 encrypted
+    private String password; // will be stored as Base64 encrypted
+    private List<String> roles;
     private List<String> blogs;
 
-    public User() {}
+    public User() {
+    }
 
-    public User(String name, String username, String email, String password, List<String> blogs) {
+    public User(String name, String username, String email, String password, List<String> roles, List<String> blogs) {
         this.name = name;
         this.username = username;
         this.email = email;
         this.password = password;
+        this.roles = roles;
         this.blogs = blogs;
     }
 
     // Getters & Setters
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
+    public String getName() {
+        return name;
+    }
 
-    public String getUsername() { return username; }
-    public void setUsername(String username) { this.username = username; }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
+    public String getUsername() {
+        return username;
+    }
 
-    public String getPassword() { return password; }
-    public void setPassword(String password) { this.password = password; }
+    public void setUsername(String username) {
+        this.username = username;
+    }
 
-    public List<String> getBlogs() { return blogs; }
-    public void setBlogs(List<String> blogs) { this.blogs = blogs; }
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public List<String> getBlogs() {
+        return blogs;
+    }
+
+    public void setBlogs(List<String> blogs) {
+        this.blogs = blogs;
+    }
 }

--- a/src/main/java/com/hacktober/blog/user/UserController.java
+++ b/src/main/java/com/hacktober/blog/user/UserController.java
@@ -3,11 +3,20 @@ package com.hacktober.blog.user;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import com.hacktober.blog.exceptions.ResourceNotFoundException;
-import com.hacktober.blog.utils.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hacktober.blog.exceptions.ResourceNotFoundException;
+import com.hacktober.blog.utils.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,13 +28,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class UserController {
 
     private final UserService userService;
+
     public UserController(UserService userService) {
         this.userService = userService;
     }
 
     @PostMapping("/create")
     @Operation(summary = "Create user", description = "Persist a new user profile in the database.")
-    public ResponseEntity<ApiResponse<String>> createUser(@RequestBody User user) throws InterruptedException, ExecutionException {
+    public ResponseEntity<ApiResponse<String>> createUser(@RequestBody User user)
+            throws InterruptedException, ExecutionException {
         String result = userService.create(user);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(result, "User created successfully"));
@@ -33,7 +44,8 @@ public class UserController {
 
     @GetMapping("/{username}")
     @Operation(summary = "Get user", description = "Retrieve a single user by username.")
-    public ResponseEntity<ApiResponse<User>> getUser(@PathVariable String username) throws InterruptedException, ExecutionException {
+    public ResponseEntity<ApiResponse<User>> getUser(@PathVariable String username)
+            throws InterruptedException, ExecutionException {
         User user = userService.getByUsername(username);
         if (user == null) {
             throw new ResourceNotFoundException("User with username '" + username + "' not found");
@@ -50,7 +62,8 @@ public class UserController {
 
     @PutMapping("/{username}")
     @Operation(summary = "Update user", description = "Update a user's profile data, keeping the username immutable.")
-    public ResponseEntity<ApiResponse<String>> updateUser(@PathVariable String username, @RequestBody User user) throws InterruptedException, ExecutionException {
+    public ResponseEntity<ApiResponse<String>> updateUser(@PathVariable String username, @RequestBody User user)
+            throws InterruptedException, ExecutionException {
         user.setUsername(username); // ensure username remains the document ID
         String result = userService.update(user);
         return ResponseEntity.ok(ApiResponse.success(result, "User updated successfully"));
@@ -58,7 +71,8 @@ public class UserController {
 
     @DeleteMapping("/{username}")
     @Operation(summary = "Delete user", description = "Remove a user and their profile information.")
-    public ResponseEntity<ApiResponse<String>> deleteUser(@PathVariable String username) throws InterruptedException, ExecutionException {
+    public ResponseEntity<ApiResponse<String>> deleteUser(@PathVariable String username)
+            throws InterruptedException, ExecutionException {
         String result = userService.delete(username);
         return ResponseEntity.ok(ApiResponse.success(result, "User deleted successfully"));
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,7 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 spring.mail.properties.mail.smtp.starttls.required=true
 redis.password = ${REDIS_PASSWORD}
 notifications.enabled=${NOTIFICATIONS_ENABLED:true}
+
+# JWT Configuration
+jwt.secret=mySecretKey12345678901234567890123456789012345678901234567890
+jwt.expiration=86400000


### PR DESCRIPTION
Fixes #12 )

Implement JWT-based authentication for the blog application by adding JwtAuthenticationFilter to handle token validation and user authentication on each request, JwtUtils for token generation, parsing, and validation, and updating SecurityConfig to integrate the filter into the security chain. This enables stateless authentication using Bearer tokens, securing endpoints while allowing public access to login and registration routes.

## Translation PR

- **Language:** <lang>
- **Files translated:** list files
- **Translator:** @yourusername
- **Type:** machine / human

### Checklist
- [ ] Root English docs (`docs/en/`) untouched
- [ ] Translator credit added to each translated file
- [ ] Links/code blocks checked
- [ ] Native-speaker review requested
