### PR TITLE
Fix: Update Springdoc version to 2.7.0 to resolve Swagger UI crash on Spring Boot 3.5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.6.0</version>
+            <version>2.7.0</version>
         </dependency>
 
 		<dependency>


### PR DESCRIPTION
**Problem:**  
When accessing Swagger UI, the project crashes with the following error:

`Handler dispatch failed: java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'`

**Reason:** Version incompatibility between `springdoc-openapi-starter-webmvc-ui:2.6.0` and `Spring Boot 3.5.x`

**Solution:**  Updated `springdoc-openapi-starter-webmvc-ui` to `2.7.0`

**Verification:**  
- Ran the app locally: `./mvnw spring-boot:run`
- Accessed Swagger UI: http://localhost:8080/swagger-ui/index.html  
- Verified endpoints working

**Hacktoberfest Note:**  
I am a newbie contributing for the first time. Apologies for any mistakes.