### PR TITLE
feat(docker): add docker-compose and environment config for redis and app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Gmail Configuration for email service
+# Enable 2-factor authentication and generate an app password
+GMAIL_ACCOUNT=your-email@gmail.com
+GMAIL_APP_KEY=your-app-password
+
+# Redis password for caching
+REDIS_PASSWORD=redispassword
+
+# Application Configuration
+NOTIFICATIONS_ENABLED=true
+AUTH_JWT_SECRET=my-secret-key-change-in-production

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  # Redis service for caching
+  redis:
+    image: redis:7-alpine
+    container_name: blog-redis
+    ports:
+      - "6380:6379"
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}
+    command: redis-server --requirepass ${REDIS_PASSWORD:-redispassword}
+    volumes:
+      - redis_data:/data
+
+  # Main Spring Boot application
+  blog-backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: blog-backend
+    ports:
+      - "8080:8080"
+    environment:
+      - GMAIL_ACCOUNT=${GMAIL_ACCOUNT:-your-email@gmail.com}
+      - GMAIL_APP_KEY=${GMAIL_APP_KEY:-your-app-password}
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-redispassword}
+      - NOTIFICATIONS_ENABLED=${NOTIFICATIONS_ENABLED:-true}
+      - AUTH_JWT_SECRET=${AUTH_JWT_SECRET:-my-secret-key}
+    depends_on:
+      - redis
+    volumes:
+      - ./logs:/app/logs
+
+volumes:
+  redis_data:


### PR DESCRIPTION
## CHANGE LIST for PR #37

### Summary

Add example environment variables and a docker-compose setup to run the Spring Boot backend and a local Redis instance.

### Files added:
- .env.example — example environment variables and secrets placeholders
- docker-compose.yml — Compose file to run Redis and the blog-backend